### PR TITLE
fix: add maxWorkers: 1 to jest config to prevent flaky auth tests

### DIFF
--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   roots: ["src"],
   testMatch: ["**/*.test.ts"],
   setupFiles: ["dotenv/config"],
+  maxWorkers: 1,
   extensionsToTreatAsEsm: [".ts"],
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",


### PR DESCRIPTION
## Summary
- Adds `maxWorkers: 1` to `packages/server/jest.config.js` to force sequential test suite execution

## Why
Multiple test suites share `deleteTableAuth()` in their `afterAll` hooks (`auth.test.ts` and `attendee.test.ts`). Without `maxWorkers: 1`, jest runs suites concurrently — `attendee.test.ts`'s `afterAll` can delete auth rows while `auth.test.ts` is mid-registration (between the `INSERT INTO auth` and the FK-checked `INSERT INTO client`), causing intermittent `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed` failures.

This was the root cause of the flaky CI failure seen on `feature/dog-walking-app` after PR #94 was merged.

## Test plan
- [ ] CI should pass consistently with auth tests no longer racing against `deleteTableAuth` from attendee suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Ajustada a configuração de execução dos testes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->